### PR TITLE
Created new directive to tidy search results with external hrefs

### DIFF
--- a/src/app/components/search-results/search-result-link/search-result-link.directive.ts
+++ b/src/app/components/search-results/search-result-link/search-result-link.directive.ts
@@ -1,0 +1,28 @@
+import { Directive, ElementRef, Input, AfterViewInit, HostListener } from '@angular/core';
+import { ListItem } from 'app/model/ListItem';
+import { AnalyticsService } from 'app/services/analytics.service';
+import {ActivatedRoute} from '@angular/router';
+
+@Directive({
+    selector: '[appSearchResultLink]'
+})
+export class SearchResultLinkDirective implements AfterViewInit {
+    @Input() item: ListItem;
+
+    constructor(private el: ElementRef, private analyticsService: AnalyticsService, private route: ActivatedRoute) {}
+
+    @HostListener('click') click() {
+       if (this.item.type === 'policy') {
+           this.analyticsService.trackPolicy(this.item.title, this.item.url);
+       }
+   }
+
+    ngAfterViewInit() {
+        if (this.item.type === 'policy') {
+            this.el.nativeElement.href = this.item.url;
+            this.el.nativeElement.target = '_blank';
+        } else {
+            this.el.nativeElement.href = '#/' + this.item.type + '/' + this.item.id.toString();
+        }
+    }
+}

--- a/src/app/components/search-results/search-results.component.html
+++ b/src/app/components/search-results/search-results.component.html
@@ -61,54 +61,45 @@
 
   <mat-nav-list *ngIf="!showCardView">
     <ng-container *ngFor="let item of resultsPage.content">
-      <ng-container *ngIf="item.type !== 'policy'">
-        <mat-list-item class="list-item" [routerLink]="item | listItemToRouterLink">
-          <img mat-list-avatar [src]="apiService.getAssetUrl(item.image)">
-          <p mat-line class="item-title">{{item.title}}</p>
-          <p mat-line class="item-subtitle">{{item.subtitle}}</p>
-          <mat-chip-list mat-line style="overflow: hidden;height: 18px;">
-            <mat-chip disabled *ngFor="let category of item.categories" style="cursor: pointer;"><span style="color: #004059;">{{category}}</span></mat-chip>
-          </mat-chip-list>
-        </mat-list-item>
-      </ng-container>
-
-      <ng-container *ngIf="item.type === 'policy'">
-        <a mat-list-item class="list-item" [href]="item.url" target="_blank" (click)="trackOutboundLink(item)">
-          <img mat-list-avatar [src]="apiService.getAssetUrl(item.image)">
-          <p mat-line class="item-title">{{item.title}}</p>
-          <p mat-line class="item-subtitle">{{item.subtitle}}</p>
-          <mat-chip-list mat-line style="overflow: hidden;height: 18px;">
-            <mat-chip disabled *ngFor="let category of item.categories" style="margin-bottom: 2px;cursor: pointer;"><span style="color: #004059;">{{category}}</span></mat-chip>
-          </mat-chip-list>
+      <ng-container>
+        <a appSearchResultLink [item]="item">
+          <mat-list-item class="list-item">
+              <img mat-list-avatar [src]="apiService.getAssetUrl(item.image)">
+              <p mat-line class="item-title">{{item.title}}</p>
+              <p mat-line class="item-subtitle">{{item.subtitle}}</p>
+              <mat-chip-list mat-line style="overflow: hidden;height: 18px;">
+                <mat-chip disabled *ngFor="let category of item.categories" style="cursor: pointer;"><span style="color: #004059;">{{category}}</span></mat-chip>
+              </mat-chip-list>
+          </mat-list-item>
         </a>
       </ng-container>
     </ng-container>
   </mat-nav-list>
 
-  <!--Testing Card View for Results-->
   <mat-grid-list *ngIf="showCardView" [cols]="cardViewResultsNumberOfColumns" gutterSize="1em" rowHeight="1:2" style="padding-top: 1em">
-    <mat-grid-tile *ngFor="let item of resultsPage.content;" [colspan]="1" [rowspan]="1" [routerLink]="item | listItemToRouterLink" style="cursor: pointer">
-      <div class="card-result-image">
-        <img src="{{apiService.getAssetUrl(item.image)}}" style="width: 100%; height: 100%;"/>
-      </div>
-      <div class="card-result-content">
-        <div class="card-result-title">
-          {{item.title}}
+    <mat-grid-tile *ngFor="let item of resultsPage.content;" [colspan]="1" [rowspan]="1">
+      <a appSearchResultLink [item]="item">
+        <div class="card-result-image">
+          <img src="{{apiService.getAssetUrl(item.image)}}" style="width: 100%; height: 100%;"/>
         </div>
-        <div class="card-result-subtitle">
-          {{item.subtitle}}
+        <div class="card-result-content">
+          <div class="card-result-title">
+            {{item.title}}
+          </div>
+          <div class="card-result-subtitle">
+            {{item.subtitle}}
+          </div>
+          <div class="card-result-chip-list">
+            <mat-chip-list mat-line style="overflow: hidden; height: 1em;">
+              <mat-chip disabled *ngFor="let category of item.categories" style="margin: 2px 2px 2px 0px; cursor: pointer; background-color: #fff; height: .5em">
+                <span style="color: #004059;font-size: small;">{{category}}</span>
+              </mat-chip>
+            </mat-chip-list>
+          </div>
         </div>
-        <div class="card-result-chip-list">
-          <mat-chip-list mat-line style="overflow: hidden; height: 1em;">
-            <mat-chip disabled *ngFor="let category of item.categories" style="margin: 2px 2px 2px 0px; cursor: pointer; background-color: #fff; height: .5em">
-              <span style="color: #004059;font-size: small;">{{category}}</span>
-            </mat-chip>
-          </mat-chip-list>
-        </div>
-      </div>
+      </a>
     </mat-grid-tile>
   </mat-grid-list>
-  <!------------------------------------------------------------------------------------------>
 
 
   <mat-paginator class="search-paginator"

--- a/src/app/components/search-results/search-results.module.ts
+++ b/src/app/components/search-results/search-results.module.ts
@@ -8,7 +8,7 @@ import {FilterDialogComponent} from './filter-dialog/filter-dialog.component';
 import {ResearchActivityInputComponent} from './research-activity-input/research-activity-input.component';
 import {MatTagsComponent} from './mat-tags/mat-tags.component';
 import {SearchFiltersComponent} from './search-filters/search-filters.component';
-
+import {SearchResultLinkDirective} from './search-result-link/search-result-link.directive';
 
 @NgModule({
   imports: [
@@ -21,7 +21,8 @@ import {SearchFiltersComponent} from './search-filters/search-filters.component'
     ResearchActivityInputComponent,
     FilterDialogComponent,
     MatTagsComponent,
-    SearchFiltersComponent
+    SearchFiltersComponent,
+    SearchResultLinkDirective
   ],
   entryComponents: [
     FilterDialogComponent


### PR DESCRIPTION
Created new `@Directive` `appSearchResultLink`. This sets several attributes of a search result link based on the content type. Works in both list and card views. Requires `@Input` binding `item` of type `ListItem`.

`<a appSearchResultLink [item]="item">`

Was originally designed to fix a bug where external hrefs didn't work in the card view. Has now also been applied to the list view in order to tidy and reduce existing code.