### PR TITLE
Avoid Angular warnings on filter visibility states

### DIFF
--- a/src/app/components/search-results/mat-tags/mat-tags.component.html
+++ b/src/app/components/search-results/mat-tags/mat-tags.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex="100" [ngClass]="{'disabled':isDisabled}">
+<mat-form-field fxFlex="100" [ngClass]="{'disabled':isDisabled}" (click)="triggerAutocomplete()">
   <mat-chip-list #chipList>
     <div>
       <ng-container *ngFor="let tag of _value; let last = last">
@@ -14,7 +14,8 @@
       </ng-container>
     </div>
 
-    <input [matChipInputFor]="chipList"
+    <input [disabled]="isDisabled"
+           [matChipInputFor]="chipList"
            [matChipInputAddOnBlur]="false"
            [matAutocomplete]="auto"
            [placeholder]="placeholder"

--- a/src/app/components/search-results/mat-tags/mat-tags.component.html
+++ b/src/app/components/search-results/mat-tags/mat-tags.component.html
@@ -1,4 +1,4 @@
-<mat-form-field fxFlex="100" [ngClass]="{'disabled':disabled}" (click)="triggerAutocomplete()">
+<mat-form-field fxFlex="100" [ngClass]="{'disabled':isDisabled}">
   <mat-chip-list #chipList>
     <div>
       <ng-container *ngFor="let tag of _value; let last = last">
@@ -14,8 +14,7 @@
       </ng-container>
     </div>
 
-    <input [disabled]="disabled"
-           [matChipInputFor]="chipList"
+    <input [matChipInputFor]="chipList"
            [matChipInputAddOnBlur]="false"
            [matAutocomplete]="auto"
            [placeholder]="placeholder"

--- a/src/app/components/search-results/mat-tags/mat-tags.component.ts
+++ b/src/app/components/search-results/mat-tags/mat-tags.component.ts
@@ -57,8 +57,6 @@ export class MatTagsComponent implements ControlValueAccessor, OnChanges {
 
   @Input() placeholder = '';
 
-  @Input() disabled = false;
-
   @Input()
   set value(v: Tag[]) {
     this.onChange(v);
@@ -68,12 +66,18 @@ export class MatTagsComponent implements ControlValueAccessor, OnChanges {
     return this._value;
   }
 
+  isDisabled : boolean;
+
   onChange = (_: any): void => {
     // mock
   };
   onTouched = (_: any): void => {
     // mock
   };
+
+  setDisabledState(isDisabled){
+    this.isDisabled = isDisabled;
+  }
 
   writeValue(v: Tag[]): void {
     this._value = v;
@@ -126,7 +130,8 @@ export class MatTagsComponent implements ControlValueAccessor, OnChanges {
   }
 
   triggerAutocomplete(){
-    if (this.disabled){
+    console.log("Is this disabled?",this.isDisabled);
+    if (this.isDisabled){
       return;
     }
     if (!this.autoTrigger.panelOpen){

--- a/src/app/components/search-results/mat-tags/mat-tags.component.ts
+++ b/src/app/components/search-results/mat-tags/mat-tags.component.ts
@@ -130,7 +130,6 @@ export class MatTagsComponent implements ControlValueAccessor, OnChanges {
   }
 
   triggerAutocomplete(){
-    console.log("Is this disabled?",this.isDisabled);
     if (this.isDisabled){
       return;
     }

--- a/src/app/components/search-results/research-activity-input/research-activity-input.component.html
+++ b/src/app/components/search-results/research-activity-input/research-activity-input.component.html
@@ -1,8 +1,8 @@
-<div [ngClass]="{'disabled':disabled}" >
+<div [ngClass]="{'disabled':isDisabled}" >
 <span style="color: rgba(0,0,0,0.54);padding-bottom: 0.5em;display: block;">Limit items by research activity</span>
 <div class="inputs" [ngClass]="{'touch':touchFriendly}" fxLayout="column">
   <mat-slide-toggle *ngFor="let activity of optionsService.researchActivityOptions"
-                    [disabled]="disabled"
+                    [disabled]="isDisabled"
                   [ngClass]="[activity.className]"
                   [checked]="model[activity.id].selected"
                   (change)="onToggle(activity.id,$event)">

--- a/src/app/components/search-results/research-activity-input/research-activity-input.component.ts
+++ b/src/app/components/search-results/research-activity-input/research-activity-input.component.ts
@@ -30,8 +30,7 @@ export class ResearchActivityInputComponent implements OnInit, ControlValueAcces
    */
   @Input() touchFriendly : boolean = false;
 
-  @Input() disabled : boolean = false;
-
+  isDisabled : boolean;
 
   get value() {
     return this._value;
@@ -51,6 +50,10 @@ export class ResearchActivityInputComponent implements OnInit, ControlValueAcces
   }
 
   ngOnInit() {
+  }
+
+  setDisabledState(isDisabled){
+    this.isDisabled = isDisabled;
   }
 
   onToggle(activityId,toggleEvent) {

--- a/src/app/components/search-results/search-filters/search-filters.component.html
+++ b/src/app/components/search-results/search-filters/search-filters.component.html
@@ -1,7 +1,6 @@
 <form *ngIf="filtersForm" [formGroup]="filtersForm" fxLayout="column" fxLayoutGap="2.5em" fxLayoutGap.xs="1em">
   <div fxFlex="noshrink">
     <app-research-activity-input style="display: block;"
-                                 [disabled]="!showResearchActivityFilter"
                                  formControlName="researchActivityIds"
                                  [touchFriendly]="compact"></app-research-activity-input>
 
@@ -26,9 +25,9 @@
     </div>
 
     <div fxLayout="column" fxLayoutGap="1em">
-      <app-mat-tags [disabled]="!showPersonFilter" [placeholder]="'Refine by person&#8230;'"
+      <app-mat-tags [placeholder]="'Refine by person&#8230;'"
                     [addNew]="false" [source]="personTagSource" formControlName="personTags"></app-mat-tags>
-      <app-mat-tags [disabled]="!showOrgUnitFilter" [placeholder]="'Refine by organisation unit&#8230;'"
+      <app-mat-tags [placeholder]="'Refine by organisation unit&#8230;'"
                     [addNew]="false" [source]="orgUnitTagSource" formControlName="orgUnitTags"></app-mat-tags>
     </div>
   </div>

--- a/src/app/components/search-results/search-filters/search-filters.component.ts
+++ b/src/app/components/search-results/search-filters/search-filters.component.ts
@@ -30,10 +30,6 @@ export class SearchFiltersComponent implements OnInit, OnDestroy {
   @Input()
   public compact : boolean = false;
 
-  public showPersonFilter = true;
-  public showOrgUnitFilter = true;
-  public showResearchActivityFilter = true;
-
   public personTagSource: Tag[] = [];
   public orgUnitTagSource: Tag[] = [];
 
@@ -100,8 +96,5 @@ export class SearchFiltersComponent implements OnInit, OnDestroy {
     } else {
       controls.researchActivityIds.disable();
     }
-    //this.showPersonFilter = visibilities['person'];
-    //this.showOrgUnitFilter = visibilities['orgUnit'];
-    //this.showResearchActivityFilter = visibilities['researchActivity'];
   }
 }

--- a/src/app/components/search-results/search-filters/search-filters.component.ts
+++ b/src/app/components/search-results/search-filters/search-filters.component.ts
@@ -83,9 +83,25 @@ export class SearchFiltersComponent implements OnInit, OnDestroy {
   }
 
   updateFilterVisibility(categoryId: number) {
-    const visibilities = SearchResultsComponent.getFilterVisibility(categoryId);
-    this.showPersonFilter = visibilities['person'];
-    this.showOrgUnitFilter = visibilities['orgUnit'];
-    this.showResearchActivityFilter = visibilities['researchActivity'];
+    const visibilities = SearchResultsComponent.getFilterVisibility(categoryId),
+    controls = this.filtersForm.controls;
+    if (visibilities['person']){
+      controls.personTags.enable();
+    } else {
+      controls.personTags.disable();
+    }
+    if (visibilities['orgUnit']){
+      controls.orgUnitTags.enable();
+    } else {
+      controls.orgUnitTags.disable();
+    }
+    if (visibilities['researchActivity']){
+      controls.researchActivityIds.enable();
+    } else {
+      controls.researchActivityIds.disable();
+    }
+    //this.showPersonFilter = visibilities['person'];
+    //this.showOrgUnitFilter = visibilities['orgUnit'];
+    //this.showResearchActivityFilter = visibilities['researchActivity'];
   }
 }

--- a/src/app/components/search-results/search-results-component.service.ts
+++ b/src/app/components/search-results/search-results-component.service.ts
@@ -45,7 +45,7 @@ export class SearchResultsComponentService {
       });
   }
 
-  private initialiseSubjects(){
+  initialiseSubjects(){
     // We initialise the Subjects with an empty initial value.
     this.resultsSubject = new BehaviorSubject<Page<ListItem>>(<Page<ListItem>>{});
     this.results$ = this.resultsSubject.asObservable();

--- a/src/app/components/search-results/search-results.component.spec.ts
+++ b/src/app/components/search-results/search-results.component.spec.ts
@@ -1,0 +1,77 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SearchResultsComponent } from './search-results.component';
+import { SearchResultsModule } from './search-results.module';
+import { ServicesModule } from 'app/services/services.module';
+import { SearchBarService } from '../search-bar/search-bar.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterModule, ActivatedRoute } from '@angular/router';
+import { Location,LocationStrategy } from '@angular/common';
+import { SpyLocation, MockLocationStrategy } from '@angular/common/testing';
+import { AppComponentService } from 'app/app.component.service';
+import { SearchFiltersService } from './search-filters/search-filters.service';
+import { ResearchHubApiService } from 'app/services/research-hub-api.service';
+import { SearchResultsComponentService } from './search-results-component.service';
+import { Observable } from 'rxjs';
+
+class SearchResultsComponentStubService {
+  public results$ : Observable<any> = Observable.of([]);
+  public resultsLoading$ : Observable<boolean> = Observable.of(false);
+  public searchWithParams(params: any){
+    return;
+  }
+
+  initialiseSubjects(){
+    return;
+  }
+}
+
+describe('SearchResultsComponent', () => {
+  let component: SearchResultsComponent;
+  let fixture: ComponentFixture<SearchResultsComponent>;
+  let mockRoute : ActivatedRoute = {} as ActivatedRoute;
+  function expectToHandleNulls(fn,expectedValue,thisArg){
+    const undefinedArgs = [],
+    nullArgs = [];
+    // Create an array of undefined and null values for all arguments.
+    for (var i = 0; i < fn.length; i++){
+      undefinedArgs.push(undefined);
+      nullArgs.push(null);
+    }
+    expect(fn.apply(thisArg,undefinedArgs)).toBe(expectedValue,'successful and return expected value.');
+    expect(fn.apply(thisArg,nullArgs)).toBe(expectedValue,'successful and return expected value.');
+  }
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [ HttpClientTestingModule, ServicesModule, RouterModule ],
+      providers: [ SearchBarService,
+                   AppComponentService,
+                   SearchFiltersService,
+                   ResearchHubApiService,
+                   {provide: SearchResultsComponentService, useClass:SearchResultsComponentStubService},
+                   {provide: ActivatedRoute, useValue: mockRoute},
+                   {provide: Location, useClass: SpyLocation},
+                   {provide: LocationStrategy, useClass: MockLocationStrategy}]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SearchResultsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('#fromTags should handle null tags', () => {
+    expectToHandleNulls(component.fromTags, [], component);
+  });
+
+  it('#setFiltersIfUndefined should handle null tags', ()=> {
+    expectToHandleNulls(component.setFiltersTextIfUndefined, [], component);
+  });
+});

--- a/src/app/components/search-results/search-results.component.ts
+++ b/src/app/components/search-results/search-results.component.ts
@@ -139,6 +139,7 @@ export class SearchResultsComponent implements OnInit, OnDestroy {
 
 
   fromTags(tags: Tag[]) {
+    if (tags == null) return [];
     return tags.map(tag => tag.id);
   }
 
@@ -322,6 +323,9 @@ export class SearchResultsComponent implements OnInit, OnDestroy {
     // To be filled with API request observables
     const observablePersonBatch = [];
     const observableOrgUnitBatch = [];
+
+    if (!personTags) { personTags = [];}
+    if (!orgUnitTags) { orgUnitTags = [];}
 
     // Queue up API requests for persons and orgUnits
     orgUnitTags.forEach(key => observableOrgUnitBatch.push(this.apiService.getOrgUnit(key.id)));

--- a/src/app/components/search-results/search-results.component.ts
+++ b/src/app/components/search-results/search-results.component.ts
@@ -33,6 +33,7 @@ import {forkJoin} from 'rxjs/observable/forkJoin';
 
 import {SearchFiltersService} from './search-filters/search-filters.service';
 import { SearchResultsComponentService } from './search-results-component.service';
+import { debounceTime,distinctUntilChanged } from 'rxjs/operators';
 
 // The screen size at which we should switch to opening filters in dialog or sidenav.
 const FILTER_VIEW_BREAKPOINT = "md";
@@ -244,9 +245,9 @@ export class SearchResultsComponent implements OnInit, OnDestroy {
     // Subscribe to search parameter changes
     this.searchChangeSub = Observable
       .combineLatest(
-        this.searchBarService.searchTextChange.debounceTime(250).distinctUntilChanged(),
-        this.filtersForm.valueChanges.distinctUntilChanged(),
-        this.pageEventChange.distinctUntilChanged(),
+        this.searchBarService.searchTextChange.pipe(debounceTime(250),distinctUntilChanged()),
+        this.filtersForm.valueChanges.pipe(distinctUntilChanged()),
+        this.pageEventChange.pipe(distinctUntilChanged()),
         this.orderByChange
       )
       .debounceTime(100)

--- a/src/app/services/analytics.service.ts
+++ b/src/app/services/analytics.service.ts
@@ -24,6 +24,7 @@ export class AnalyticsService {
 
   // This method needs to be called first to initalise Google Analytics
   private initialize() {
+    if (typeof ga === 'undefined') { return; }
     ga('create', environment.analyticsCode, 'auto');
   }
 
@@ -95,12 +96,14 @@ export class AnalyticsService {
   }
 
   trackPageView(url: string, title: string) {
+    if (typeof ga === 'undefined') { return; }
     ga('set', 'page', url);
     ga('set', 'title', title);
     ga('send', 'pageview');
   }
 
   trackEvent(eventCategory, eventAction, eventLabel) {
+    if (typeof ga === 'undefined') { return; }
     ga('set', 'eventCategory', eventCategory);
     ga('set', 'eventAction', eventAction);
     ga('set', 'eventLabel', eventLabel);


### PR DESCRIPTION
When the filter panel was created, it used the disabled property on the filter controls to make them disabled. This is not recommended by Angular, because the FormControl class already has a disabled state. It caused warnings to be emitted. 
This pull request changes the search filters to use the FormControl disabled state as recommended.
The changes caused some functions to throw errors because they don't handle undefined as arguments. I have made them handle undefined as arguments and tests have been added. 