### PR TITLE
Clear mat tags input field when filter form is reset

### DIFF
--- a/src/app/components/search-results/filter-dialog/filter-dialog.component.ts
+++ b/src/app/components/search-results/filter-dialog/filter-dialog.component.ts
@@ -17,7 +17,7 @@ export class FilterDialogComponent {
   }
 
   public clear() {
-    this.filtersForm.patchValue(DEFAULT_FILTERS_VALUE);
+    this.filtersForm.reset(DEFAULT_FILTERS_VALUE);
   }
 
   public save(){

--- a/src/app/components/search-results/filter-sidenav/filter-sidenav.component.ts
+++ b/src/app/components/search-results/filter-sidenav/filter-sidenav.component.ts
@@ -18,7 +18,7 @@ export class FilterSidenavComponent implements OnInit {
   }
 
   clear(){
-    this.filtersForm.patchValue(DEFAULT_FILTERS_VALUE);
+    this.filtersForm.reset(DEFAULT_FILTERS_VALUE);
   }
 
   done(){

--- a/src/app/components/search-results/mat-tags/mat-tags.component.ts
+++ b/src/app/components/search-results/mat-tags/mat-tags.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, ViewChild, forwardRef, OnChanges, SimpleChanges} from '@angular/core';
+import {Component, Input, ViewChild, forwardRef, OnChanges, SimpleChanges, Optional} from '@angular/core';
 import {
   MatInput
 } from '@angular/material/input';
@@ -8,10 +8,13 @@ import {
 } from '@angular/material/autocomplete';
 import {
   FormControl,
+  ControlContainer,
   ControlValueAccessor,
   NG_VALUE_ACCESSOR,
   NG_VALIDATORS
 } from '@angular/forms';
+
+
 
 export interface Tag {
   id: number;
@@ -59,8 +62,11 @@ export class MatTagsComponent implements ControlValueAccessor, OnChanges {
 
   @Input() disabled = false;
 
+  @Input() formControlName: string;
+
   @Input()
   set value(v: Tag[]) {
+    this.onTouched();
     this.onChange(v);
   }
 
@@ -75,8 +81,22 @@ export class MatTagsComponent implements ControlValueAccessor, OnChanges {
     // mock
   };
 
+
+  constructor (@Optional private controlContainer: ControlContainer) {
+  }
+
   writeValue(v: Tag[]): void {
     this._value = v;
+    if (this.controlContainer && this.formControlName){
+      const control = this.controlContainer.control.get(this.formControlName);
+      if (!!control){
+        const isPristine = control.pristine;
+        if ((!v || v.length === 0) && isPristine){
+          this.chipInput.nativeElement.value = ""; // Clear the input when form is reset.
+          this.textChanged(""); // Reset autocomplete suggestions too.
+        }
+      }
+    }
 
     // If value changes and source exists, then populate _value with Tag objects
     if (this.source && this.source.length) {


### PR DESCRIPTION
Steps to reproduce
1. Go to Research Hub homepage.
2. Click on "Plan & Design".
3. In the filter panel, enter the text "ben".
4. Click on "Reset"
5. Notice that "ben" is not cleared from the input field.
Expected result
"ben" should be cleared from the field.

This was one of the findings from the user study.