### PR TITLE
Fix empty category count on pages other than the first page

### DIFF
--- a/src/app/components/request-vm/request-vm.component.html
+++ b/src/app/components/request-vm/request-vm.component.html
@@ -4,7 +4,7 @@
     <h1>{{title}}</h1>
   </mat-card-header>
 
-  <p style="padding-left: 24px;">In order to request a virtual machine, please book a consultation with us to discuss required details. A consultation typically takes 30 minutes. No preparation on your side is necessary. If you have any questions please put them into the comments field.</p>
+  <p style="padding-left: 24px;">In order to request a virtual machine, please book a consultation with us to discuss details like the desired operating system, software, memory, storage and processing power. A consultation typically takes 30 minutes. No preparation on your side is necessary. If you have any questions please put them into the comments field.</p>
 
   <div #resultsDummyHeader style="margin-top: 3em;"></div>
   <mat-horizontal-stepper #stepper linear>
@@ -39,8 +39,7 @@
 
           <div class="form-group">
             <h3>Location</h3>
-            <p>Please meet us at 23 Symonds Street, Building 302, Floor 5, Room 585 or make alternative arrangements with us
-              through the comments field.</p>
+            <p>Our office is at 23 Symonds Street, Building 302, Floor 5, Room 585. We will contact you to confirm the time and arrange the location.</p>
           </div>
 
           <div class="form-group">
@@ -67,6 +66,7 @@
       <div class="step-form-container">
         <h3>Request submitted</h3>
         <p>Your virtual machine consultation request has been submitted and an acknowledgement e-mail sent to <a *ngIf="authService.user" [href]="'mailto:' + authService.user.mail" target="_blank">{{authService.user.mail}}</a>.</p>
+        <p>We will contact you to confirm the time and arrange the location.</p>
         <p>You may view your request here: <a *ngIf="response" [href]="response.ticketUrl"  target="_blank">{{response.ticketNumber}}</a></p>
       </div>
       <div fxLayout="column" fxLayoutAlign="end">

--- a/src/app/services/research-hub-api.service.ts
+++ b/src/app/services/research-hub-api.service.ts
@@ -267,6 +267,7 @@ export class ResearchHubApiService {
   // Same query as above, but returns total number of results from each category
   getSearchResultsCategories(params: SearchResultsParams) {
     params.setSize(65535); // Return results from all pages
+    params.setPage(0);
 
     return this.http
       .get(ResearchHubApiService.hostname + ResearchHubApiService.searchResultsUrl,


### PR DESCRIPTION
**Steps to reproduce**
1. Go to research-hub.auckland.ac.nz.
2. Type in a search term (e.g. "data") into the search box.
3. In the resulting search results page, notice that the "Check out a different category" section of the refine search panel shows various categories, along with a count of how many pages belong to those categories.
4. Scroll to the bottom of the page and click on next page.

**Expected behaviour**
The "Check out a different category" section should still show different categories and a count of pages for each category.

**Actual behaviour**
The "Check out a different category" section only shows "All".

This pull request will fix this problem.

- [x] Check that category names and count do show up in pages other than the first.
- [x] Check that the fix works for different page sizes.