### PR TITLE
Updating storage form

### DIFF
--- a/src/app/components/request-storage/request-storage.component.html
+++ b/src/app/components/request-storage/request-storage.component.html
@@ -15,7 +15,7 @@
 
         <div class="step-form-container">
           <div class="form-group">
-            <h3>Do you want to request new storage or extend existing storage?</h3>
+            <h3>Do you want to request new storage or update existing storage?</h3>
             <mat-radio-group fxLayout="column" fxLayoutGap="1em" formControlName="storageType">
               <mat-radio-button value="New">New</mat-radio-button>
               <mat-radio-button value="Existing">Existing</mat-radio-button>

--- a/src/app/components/request-storage/request-storage.component.html
+++ b/src/app/components/request-storage/request-storage.component.html
@@ -22,16 +22,6 @@
               <mat-error *ngIf="storageTypeForm.controls.storageType.invalid && storageTypeClicked">* Please choose an option</mat-error>
             </mat-radio-group>
           </div>
-
-          <div class="form-group">
-            <h3>Which of the following storage options would you like?</h3>
-            <mat-form-field floatPlaceholder="never" class="no-floating-label input-full-width">
-              <mat-select placeholder="Storage options" formControlName="storageOptions" multiple>
-                <mat-option *ngFor="let item of storageOptionsList" [value]="item">{{item}}</mat-option>
-              </mat-select>
-              <mat-error *ngIf="storageTypeForm.controls.storageOptions.invalid">* Please choose at least one item from the list</mat-error>
-            </mat-form-field>
-          </div>
         </div>
 
         <div fxLayout="column" fxLayoutAlign="end">
@@ -64,6 +54,16 @@
               <mat-error *ngIf="projectForm.controls.abstract.hasError('minlength')" align="end">{{ projectForm.controls.abstract.value ? projectForm.controls.abstract.value.length : 0  }}/50</mat-error>
               <mat-hint align="start">Min 50 Characters</mat-hint>
               <mat-hint align="end">{{ projectForm.controls.abstract.value ? projectForm.controls.abstract.value.length : 0  }}/50</mat-hint>
+            </mat-form-field>
+          </div>
+
+          <div class="form-group">
+            <h3>Which of the following storage options would you like?</h3>
+            <mat-form-field floatPlaceholder="never" class="no-floating-label input-full-width">
+              <mat-select placeholder="Storage options" formControlName="storageOptions" multiple>
+                <mat-option *ngFor="let item of storageOptionsList" [value]="item">{{item}}</mat-option>
+              </mat-select>
+              <mat-error *ngIf="projectForm.controls.storageOptions.invalid">* Please choose at least one item from the list</mat-error>
             </mat-form-field>
           </div>
 

--- a/src/app/components/request-storage/request-storage.component.html
+++ b/src/app/components/request-storage/request-storage.component.html
@@ -117,9 +117,10 @@
             </div>
 
             <div class="form-group">
-              <h3>Please provide a short name for your storage folder (e.g. GDC-data)?</h3>
+              <h3>Please provide a descriptive name for your storage folder (e.g. GDC-data)?</h3>
               <mat-form-field floatPlaceholder="never" class="no-floating-label input-full-width">
                 <input matInput placeholder="Short name [optional]" formControlName="shortName" type="text">
+                <mat-hint align="start">Avoid generic names like <i>my-project</i> or <i>my-data</i></mat-hint>
                 <mat-error *ngIf="dataInfoForm.controls.shortName.invalid">* Please enter a short name</mat-error>
               </mat-form-field>
             </div>

--- a/src/app/components/request-storage/request-storage.component.html
+++ b/src/app/components/request-storage/request-storage.component.html
@@ -119,7 +119,7 @@
             <div class="form-group">
               <h3>Please provide a descriptive name for your storage folder (e.g. GDC-data)?</h3>
               <mat-form-field floatPlaceholder="never" class="no-floating-label input-full-width">
-                <input matInput placeholder="Short name [optional]" formControlName="shortName" type="text">
+                <input matInput placeholder="Short name" formControlName="shortName" type="text">
                 <mat-hint align="start">Avoid generic names like <i>my-project</i> or <i>my-data</i></mat-hint>
                 <mat-error *ngIf="dataInfoForm.controls.shortName.invalid">* Please enter a short name</mat-error>
               </mat-form-field>

--- a/src/app/components/request-storage/request-storage.component.html
+++ b/src/app/components/request-storage/request-storage.component.html
@@ -8,31 +8,38 @@
 
   <div #resultsDummyHeader style="margin-top: 3em;"></div>
   <mat-horizontal-stepper #stepper linear="true">
-    <mat-step [editable]="isEditable" [stepControl]="storageTypeForm">
-      <form [formGroup]="storageTypeForm" novalidate>
+    <mat-step [editable]="isEditable" [stepControl]="requestTypeForm">
+      <form [formGroup]="requestTypeForm" novalidate>
 
         <ng-template matStepLabel>Request Type</ng-template>
 
         <div class="step-form-container">
           <div class="form-group">
             <h3>Do you want to request new storage or update existing storage?</h3>
-            <mat-radio-group fxLayout="column" fxLayoutGap="1em" formControlName="storageType">
+            <mat-radio-group fxLayout="column" fxLayoutGap="1em" formControlName="requestType">
               <mat-radio-button value="New">New</mat-radio-button>
               <mat-radio-button value="Existing">Existing</mat-radio-button>
-              <mat-error *ngIf="storageTypeForm.controls.storageType.invalid && storageTypeClicked">* Please choose an option</mat-error>
+              <mat-error *ngIf="requestTypeForm.controls.requestType.invalid && requestTypeClicked">* Please choose an option</mat-error>
             </mat-radio-group>
           </div>
         </div>
 
         <div fxLayout="column" fxLayoutAlign="end">
           <div fxLayout="row" fxLayoutAlign="end">
-            <button mat-raised-button color="accent" matStepperNext (click)="storageTypeClicked = true;">Next</button>
+            <button mat-raised-button color="accent" matStepperNext (click)="requestTypeClicked = true;">Next</button>
           </div>
         </div>
       </form>
     </mat-step>
 
-    <mat-step [editable]="isEditable" [stepControl]="projectForm">
+    <mat-step [editable]="isEditable" [stepControl]="requestDetailsForm" *ngIf="requestTypeForm.controls.requestType.value === 'Existing'">
+      <ng-template matStepLabel>Request Details</ng-template>
+      <form [formGroup]="requestDetailsForm">
+        <h1>Howdy!</h1>
+      </form>
+    </mat-step>
+
+    <mat-step [editable]="isEditable" [stepControl]="projectForm" *ngIf="requestTypeForm.controls.requestType.value === 'New'">  
       <form [formGroup]="projectForm" novalidate>
         <ng-template matStepLabel>General Information</ng-template>
 
@@ -97,7 +104,7 @@
       </form>
     </mat-step>
 
-    <mat-step [editable]="isEditable" [stepControl]="dataInfoForm">
+    <mat-step [editable]="isEditable" [stepControl]="dataInfoForm" *ngIf="requestTypeForm.controls.requestType.value === 'New'">
       <form [formGroup]="dataInfoForm" novalidate>
         <ng-template matStepLabel>Data Information</ng-template>
 
@@ -185,7 +192,7 @@
       </form>
     </mat-step>
 
-    <mat-step [editable]="isEditable" [stepControl]="dataSizeForm">
+    <mat-step [editable]="isEditable" [stepControl]="dataSizeForm" *ngIf="requestTypeForm.controls.requestType.value === 'New'">
       <form [formGroup]="dataSizeForm" novalidate>
         <ng-template matStepLabel>Data Size</ng-template>
 

--- a/src/app/components/request-storage/request-storage.component.html
+++ b/src/app/components/request-storage/request-storage.component.html
@@ -33,9 +33,47 @@
     </mat-step>
 
     <mat-step [editable]="isEditable" [stepControl]="requestDetailsForm" *ngIf="requestTypeForm.controls.requestType.value === 'Existing'">
-      <ng-template matStepLabel>Request Details</ng-template>
       <form [formGroup]="requestDetailsForm">
-        <h1>Howdy!</h1>
+        <ng-template matStepLabel>Request Details</ng-template>
+
+        <div class="step-form-container">
+          <div class="form-group">
+            <h3>Please provide the name of your existing research folder</h3>
+
+            <mat-form-field floatPlaceholder="never" class="no-floating-label input-full-width">
+              <input matInput placeholder="Folder name" formControlName="existingFolderName" type="text">
+              <mat-error *ngIf="requestDetailsForm.controls.existingFolderName.invalid">* Please enter folder name</mat-error>
+            </mat-form-field>
+
+
+          <div class="form-group">
+            <h3>Would you like to: </h3>
+            <mat-form-field floatPlaceholder="never" class="no-floating-label input-full-width">
+              <mat-select placeholder="Type of update" formControlName="updateType" multiple>
+                <mat-option *ngFor="let item of updateOptionsList" [value]="item">{{item}}</mat-option>
+              </mat-select>
+              <mat-error *ngIf="requestDetailsForm.controls.updateType.invalid">* Please choose at least one item from the list</mat-error>
+            </mat-form-field>
+          </div>
+
+
+          <div class="form-group">
+            <h3>Please provide details of your request</h3>
+            <mat-form-field floatPlaceholder="never" class="no-floating-label input-full-width">
+              <textarea matInput placeholder="Request Details" formControlName="requestDetails" type="text"></textarea>
+            </mat-form-field>
+          </div>
+
+
+          <div class="form-group">
+            <h3>Is there anything else you would like to tell us?</h3>
+            <mat-form-field floatPlaceholder="never" class="no-floating-label input-full-width">
+              <textarea matInput placeholder="Comments [optional]" formControlName="comments" type="text"></textarea>
+            </mat-form-field>
+          </div>
+
+          </div>
+        </div>
       </form>
     </mat-step>
 

--- a/src/app/components/request-storage/request-storage.component.html
+++ b/src/app/components/request-storage/request-storage.component.html
@@ -11,7 +11,7 @@
     <mat-step [editable]="isEditable" [stepControl]="storageTypeForm">
       <form [formGroup]="storageTypeForm" novalidate>
 
-        <ng-template matStepLabel>Storage Type</ng-template>
+        <ng-template matStepLabel>Request Type</ng-template>
 
         <div class="step-form-container">
           <div class="form-group">

--- a/src/app/components/request-storage/request-storage.component.html
+++ b/src/app/components/request-storage/request-storage.component.html
@@ -72,6 +72,16 @@
             </mat-form-field>
           </div>
 
+          <div class="step-overlay" fxLayout="row" fxLayoutAlign="center center" *ngIf="submitting">
+            <mat-spinner></mat-spinner>
+          </div>
+
+          <div fxLayout="column" fxLayoutAlign="end">
+            <div fxLayout="row" fxLayoutAlign="end">
+              <button mat-raised-button color="accent" (click)="submit(requestTypeForm.controls.requestType.value, requestDetailsForm)" [disabled]="submitting">Request Storage</button>
+            </div>
+          </div>
+
           </div>
         </div>
       </form>
@@ -285,7 +295,7 @@
 
         <div fxLayout="column" fxLayoutAlign="end">
           <div fxLayout="row" fxLayoutAlign="end">
-            <button mat-raised-button color="accent" (click)="submit()" [disabled]="submitting">Request Storage</button>
+            <button mat-raised-button color="accent" (click)="submit(requestTypeForm.controls.requestType.value, dataSizeForm)" [disabled]="submitting">Request Storage</button>
           </div>
         </div>
       </form>

--- a/src/app/components/request-storage/request-storage.component.html
+++ b/src/app/components/request-storage/request-storage.component.html
@@ -61,6 +61,7 @@
             <h3>Please provide details of your request</h3>
             <mat-form-field floatPlaceholder="never" class="no-floating-label input-full-width">
               <textarea matInput placeholder="Request Details" formControlName="requestDetails" type="text"></textarea>
+              <mat-error *ngIf="requestDetailsForm.controls.requestDetails.invalid">* Please provide details of your request</mat-error>
             </mat-form-field>
           </div>
 

--- a/src/app/components/request-storage/request-storage.component.html
+++ b/src/app/components/request-storage/request-storage.component.html
@@ -4,7 +4,7 @@
     <h1>{{title}}</h1>
   </mat-card-header>
 
-  <p style="padding-left: 24px;">In order to provide you with research storage please complete the general information in the following sections. If you have any questions feel free to add this into the comments field in Section 4.</p>
+  <p style="padding-left: 24px;">In order to provide you with research storage please complete the general information in the following sections. If you have any questions feel free to add this into the comments field at the end of the form.</p>
 
   <div #resultsDummyHeader style="margin-top: 3em;"></div>
   <mat-horizontal-stepper #stepper linear="true">

--- a/src/app/components/request-storage/request-storage.component.ts
+++ b/src/app/components/request-storage/request-storage.component.ts
@@ -134,13 +134,13 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
     this.analyticsService.trackIntegratedService(this.title, this.location.path());
 
     this.storageTypeForm = this.formBuilder.group({
-      storageType: new FormControl(undefined, Validators.required),
-      storageOptions: new FormControl(undefined, Validators.required)
+      storageType: new FormControl(undefined, Validators.required)
     });
 
     this.projectForm = this.formBuilder.group({
       title: new FormControl(undefined, Validators.required),
       abstract: new FormControl(undefined, [Validators.required, Validators.minLength(50)]),
+      storageOptions: new FormControl(undefined, Validators.required),
       endDate: new FormControl(undefined, [Validators.required]),
       fieldOfResearch: new FormControl(undefined, Validators.required),
     });

--- a/src/app/components/request-storage/request-storage.component.ts
+++ b/src/app/components/request-storage/request-storage.component.ts
@@ -60,11 +60,17 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
   public requestTypeClicked = false;
   public showSizeNextYear = true;
 
+  public updateOptionsList = [
+    'Extend Storage',
+    'Change Access',
+    'Other'
+  ];
+
   public storageOptionsList = [
     'Dropbox',
     'Network Research Storage',
     'Something else'
-  ]
+  ];
 
   public fieldOfResearchCodes = [
     '01 Mathematical Sciences',
@@ -146,7 +152,10 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
     });
 
     this.requestDetailsForm = this.formBuilder.group({
-      existingStorageFolderName: new FormControl(undefined)
+      existingFolderName: new FormControl(undefined, [Validators.required]),
+      updateType: new FormControl(undefined, [Validators.required]),
+      requestDetails: new FormControl(undefined, [Validators.required]),
+      comments: new FormControl(undefined)
     });
 
     this.projectMembers = this.formBuilder.array([], Validators.compose([Validators.required]));

--- a/src/app/components/request-storage/request-storage.component.ts
+++ b/src/app/components/request-storage/request-storage.component.ts
@@ -149,7 +149,7 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
     this.dataInfoForm = this.formBuilder.group({
       dataRequirements: new FormControl(undefined),
       dataRequirementsOther: new FormControl(undefined),
-      shortName: new FormControl(undefined),
+      shortName: new FormControl(undefined, [Validators.required]),
       projectMembers: this.projectMembers
     });
 

--- a/src/app/components/request-storage/request-storage.component.ts
+++ b/src/app/components/request-storage/request-storage.component.ts
@@ -260,6 +260,7 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
   saveRequest() {
     const form = {
       requestTypeForm: this.requestTypeForm.getRawValue(),
+      requestDetailsForm: this.requestDetailsForm.getRawValue(),
       projectForm: this.projectForm.getRawValue(),
       dataInfoForm: this.dataInfoForm.getRawValue(),
       dataSizeForm: this.dataSizeForm.getRawValue()
@@ -275,6 +276,7 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
       form = JSON.parse(form);
 
       this.requestTypeForm.setValue(form['requestTypeForm']);
+      this.requestDetailsForm.setValue(form['requestDetailsForm']);
       this.projectForm.setValue(form['projectForm']);
       this.dataInfoForm.setValue(form['dataInfoForm']);
       this.dataSizeForm.setValue(form['dataSizeForm']);

--- a/src/app/components/request-storage/request-storage.component.ts
+++ b/src/app/components/request-storage/request-storage.component.ts
@@ -48,15 +48,16 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
   public title = 'Request Research Storage';
   public image = 'content/vault.jpg';
   public response: any;
-  public storageTypeForm: FormGroup;
+  public requestTypeForm: FormGroup;
   public projectForm: FormGroup;
   public dataInfoForm: FormGroup;
   public dataSizeForm: FormGroup;
+  public requestDetailsForm: FormGroup;
   private lastStepIndex = 4;
   public isEditable = true;
   public showOtherField = false;
   public projectMembers: FormArray;
-  public storageTypeClicked = false;
+  public requestTypeClicked = false;
   public showSizeNextYear = true;
 
   public storageOptionsList = [
@@ -132,8 +133,8 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
   ngOnInit() {
     this.analyticsService.trackIntegratedService(this.title, this.location.path());
 
-    this.storageTypeForm = this.formBuilder.group({
-      storageType: new FormControl(undefined, Validators.required)
+    this.requestTypeForm = this.formBuilder.group({
+      requestType: new FormControl('New', Validators.required)
     });
 
     this.projectForm = this.formBuilder.group({
@@ -142,6 +143,10 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
       storageOptions: new FormControl(undefined, Validators.required),
       endDate: new FormControl(undefined, [Validators.required]),
       fieldOfResearch: new FormControl(undefined, Validators.required),
+    });
+
+    this.requestDetailsForm = this.formBuilder.group({
+      existingStorageFolderName: new FormControl(undefined)
     });
 
     this.projectMembers = this.formBuilder.array([], Validators.compose([Validators.required]));
@@ -225,7 +230,7 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
   }
 
   canDeactivate() {
-    if ((!this.storageTypeForm.dirty && !this.projectForm.dirty && !this.dataInfoForm.dirty && !this.dataSizeForm.dirty) || this.response !== undefined) {
+    if ((!this.requestTypeForm.dirty && !this.projectForm.dirty && !this.dataInfoForm.dirty && !this.dataSizeForm.dirty) || this.response !== undefined) {
       return true;
     }
 
@@ -246,7 +251,7 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
 
   saveRequest() {
     const form = {
-      storageTypeForm: this.storageTypeForm.getRawValue(),
+      requestTypeForm: this.requestTypeForm.getRawValue(),
       projectForm: this.projectForm.getRawValue(),
       dataInfoForm: this.dataInfoForm.getRawValue(),
       dataSizeForm: this.dataSizeForm.getRawValue()
@@ -261,7 +266,7 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
     if (form !== null) {
       form = JSON.parse(form);
 
-      this.storageTypeForm.setValue(form['storageTypeForm']);
+      this.requestTypeForm.setValue(form['requestTypeForm']);
       this.projectForm.setValue(form['projectForm']);
       this.dataInfoForm.setValue(form['dataInfoForm']);
       this.dataSizeForm.setValue(form['dataSizeForm']);
@@ -305,6 +310,7 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
   }
 
   ngOnDestroy() {
+    this.requestTypeSub.unsubscribe();
     this.routeParamsSub.unsubscribe();
     this.stepperSub.unsubscribe();
     this.dataRequirementsSub.unsubscribe();
@@ -332,7 +338,7 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
       this.submitting = true;
 
       const body = Object.assign({},
-        this.storageTypeForm.getRawValue(),
+        this.requestTypeForm.getRawValue(),
         this.projectForm.getRawValue(),
         this.dataInfoForm.getRawValue(),
         this.dataSizeForm.getRawValue());

--- a/src/app/components/request-storage/request-storage.component.ts
+++ b/src/app/components/request-storage/request-storage.component.ts
@@ -62,8 +62,7 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
   public storageOptionsList = [
     'Dropbox',
     'Network Research Storage',
-    'Archive',
-    'I don\'t know'
+    'Something else'
   ]
 
   public fieldOfResearchCodes = [

--- a/src/app/components/request-storage/request-storage.component.ts
+++ b/src/app/components/request-storage/request-storage.component.ts
@@ -53,7 +53,6 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
   public dataInfoForm: FormGroup;
   public dataSizeForm: FormGroup;
   public requestDetailsForm: FormGroup;
-  private lastStepIndex = 4;
   public isEditable = true;
   public showOtherField = false;
   public projectMembers: FormArray;
@@ -233,7 +232,7 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
         });
 
     this.stepperSub = this.stepper.selectionChange.subscribe(selection => {
-      this.isEditable = selection.selectedIndex !== this.lastStepIndex;
+      this.isEditable = selection.selectedIndex !== this.stepper._steps.length - 1;
       this.resultsDummyHeader.nativeElement.scrollIntoView();
     });
   }
@@ -280,7 +279,7 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
       this.dataInfoForm.setValue(form['dataInfoForm']);
       this.dataSizeForm.setValue(form['dataSizeForm']);
 
-      this.stepper.selectedIndex = this.lastStepIndex - 1; // Navigate to last step
+      this.stepper.selectedIndex = this.stepper._steps.length - 1; // Navigate to last step
     }
   }
 


### PR DESCRIPTION
# Update summary
- Implementing support for branching workflow: Different forms will be displayed based on whether a user selects that their request pertains to _New_ or _Existing_ storage
- Various labels and form fields will be updated as requested

---

# Textual updates:

## Form: `Step 1`
- [x] Label: `Storage Type` -> `Request Type`
- [x] Move field `Which of the following storage options would you like?` to `Step 2`
  - [x] Remove `Archive` option
  - [x] Change`'I don't know` -> `Something else`

## Form: Step 3
- [x] Update field: `Please provide a short name for your storage folder (e.g. GDC-data)`
  - [x] Make field required
  - [x] Change label to: `Please provide a descriptive...`
  - [x] Add subheading: `Avoid generic names like 'my-project' or 'my-data'`

# Logic updates:

## If `Existing` is selected in Form: `Step 1`:
- [x] Form becomes 3 step process: `Request Type`, `Request Details`, `Done`
  - [x] Load different set of forms
  - [x] Update stepper

- [x] Form: Step 2 becomes:
  - [x] `Input`: `Please provide the name of your research folder:`
  - [x] `Select`: Would you like to: `Extend storage`, `Change access`, `Other`
      - [x] If `Extend storage`
        - `Please provide an estimate of the amount of additional storage you will require`
       - [x] If `Change access`
         - Please provide a list of users you would like to add
       - [x] Alternative implementation: just a single `Provide Details` `input` regardless of option selected