### PR TITLE
Storage form updates 2

### DIFF
--- a/src/app/components/request-storage/request-storage.component.html
+++ b/src/app/components/request-storage/request-storage.component.html
@@ -108,8 +108,8 @@
               <mat-error *ngIf="projectForm.controls.abstract.hasError('required')">* Please enter an abstract</mat-error>
               <mat-error *ngIf="projectForm.controls.abstract.hasError('minlength')" align="start">* Please enter at least 50 characters</mat-error>
               <mat-error *ngIf="projectForm.controls.abstract.hasError('minlength')" align="end">{{ projectForm.controls.abstract.value ? projectForm.controls.abstract.value.length : 0  }}/50</mat-error>
-              <mat-hint align="start">Min 50 Characters</mat-hint>
-              <mat-hint align="end">{{ projectForm.controls.abstract.value ? projectForm.controls.abstract.value.length : 0  }}/50</mat-hint>
+              <mat-hint align="start">Min 150 Characters</mat-hint>
+              <mat-hint align="end">{{ projectForm.controls.abstract.value ? projectForm.controls.abstract.value.length : 0  }}/150</mat-hint>
             </mat-form-field>
           </div>
 

--- a/src/app/components/request-storage/request-storage.component.ts
+++ b/src/app/components/request-storage/request-storage.component.ts
@@ -107,7 +107,6 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
     'Research involving children',
     'Commercially sensitive',
     'Research involves patent application',
-    'Requires encryption on disk',
     'Need for external collaborator access',
     'Requirement to delete data at end of project',
     'Other'

--- a/src/app/components/request-storage/request-storage.component.ts
+++ b/src/app/components/request-storage/request-storage.component.ts
@@ -145,7 +145,7 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
 
     this.projectForm = this.formBuilder.group({
       title: new FormControl(undefined, Validators.required),
-      abstract: new FormControl(undefined, [Validators.required, Validators.minLength(50)]),
+      abstract: new FormControl(undefined, [Validators.required, Validators.minLength(150)]),
       storageOptions: new FormControl(undefined, Validators.required),
       endDate: new FormControl(undefined, [Validators.required]),
       fieldOfResearch: new FormControl(undefined, Validators.required),


### PR DESCRIPTION
# Minor updates to the '_Request Research Storage_' form
- [x] Remove '_Requires encryption on disk_' data information option.
- [x] Increase minimum abstract size: 50->150 characters.