### PR TITLE
set abstract length to minimum of 500

### DIFF
--- a/src/app/components/request-storage/request-storage.component.html
+++ b/src/app/components/request-storage/request-storage.component.html
@@ -106,10 +106,10 @@
             <mat-form-field class="no-floating-label input-full-width" floatLabel="never">
               <textarea matInput placeholder="Project abstract" formControlName="abstract" type="text"></textarea>
               <mat-error *ngIf="projectForm.controls.abstract.hasError('required')">* Please enter an abstract</mat-error>
-              <mat-error *ngIf="projectForm.controls.abstract.hasError('minlength')" align="start">* Please enter at least 150 characters</mat-error>
-              <mat-error *ngIf="projectForm.controls.abstract.hasError('minlength')" align="end">{{ projectForm.controls.abstract.value ? projectForm.controls.abstract.value.length : 0  }}/150</mat-error>
-              <mat-hint align="start">Min 150 Characters</mat-hint>
-              <mat-hint align="end">{{ projectForm.controls.abstract.value ? projectForm.controls.abstract.value.length : 0  }}/150</mat-hint>
+              <mat-error *ngIf="projectForm.controls.abstract.hasError('minlength')" align="start">* Please enter at least 500 characters</mat-error>
+              <mat-error *ngIf="projectForm.controls.abstract.hasError('minlength')" align="end">{{ projectForm.controls.abstract.value ? projectForm.controls.abstract.value.length : 0  }}/500</mat-error>
+              <mat-hint align="start">Min 500 Characters</mat-hint>
+              <mat-hint align="end">{{ projectForm.controls.abstract.value ? projectForm.controls.abstract.value.length : 0  }}/500</mat-hint>
             </mat-form-field>
           </div>
 

--- a/src/app/components/request-storage/request-storage.component.ts
+++ b/src/app/components/request-storage/request-storage.component.ts
@@ -145,7 +145,7 @@ export class RequestStorageComponent implements OnInit, OnDestroy, CanComponentD
 
     this.projectForm = this.formBuilder.group({
       title: new FormControl(undefined, Validators.required),
-      abstract: new FormControl(undefined, [Validators.required, Validators.minLength(150)]),
+      abstract: new FormControl(undefined, [Validators.required, Validators.minLength(500)]),
       storageOptions: new FormControl(undefined, Validators.required),
       endDate: new FormControl(undefined, [Validators.required]),
       fieldOfResearch: new FormControl(undefined, Validators.required),


### PR DESCRIPTION
When we handle a request for storage coming in from your storage-form,  we are required to enter at least 500 characters for the abstract (description), but your form asks the user to enter at least 150 characters.  