### PR TITLE
Upgrade dependencies to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # ================   Unit test stage  ================
 
-FROM          markadams/chromium-xvfb-js as test
+FROM          markadams/chromium-xvfb as test
 
 # Build args required to work behind proxy
 ARG           http_proxy
@@ -10,7 +10,7 @@ ARG           https_proxy
 RUN           apt-get update -qq && apt-get install -qqy curl build-essential git
 
 # Install nodejs and update npm to latest version
-RUN           curl -sL https://deb.nodesource.com/setup_11.x | bash -
+RUN           curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN           apt-get update -qq && apt-get install -y nodejs
 
 WORKDIR       /research-hub-web/
@@ -47,7 +47,7 @@ ARG           https_proxy
 RUN           apt-get update -qq && apt-get install -qqy curl build-essential git
 
 # Install nodejs and update npm to latest version
-RUN           curl -sL https://deb.nodesource.com/setup_11.x | bash -
+RUN           curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN           apt-get update -qq && apt-get install -y nodejs
 
 WORKDIR       /research-hub-web/

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "zone.js": "^0.8.18"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.11.0",
-    "@angular/cli": "^7.1.3",
-    "@angular/compiler-cli": "7.2.0-rc.0",
+    "@angular-devkit/build-angular": "~0.13.9",
+    "@angular/cli": "^7.3.9",
+    "@angular/compiler-cli": "^7.2.16",
     "@compodoc/compodoc": "^1.1.5",
     "@types/jasmine": "2.5.38",
     "@types/node": "^6.0.88",


### PR DESCRIPTION
The Web frontend currently uses Node v11 during its build to run tests and Angular CLI. However, Node v11 is no longer supported (https://nodejs.org/en/about/releases/), and its repositories are no longer working. This has caused Docker image builds on fresh machines to fail.

This PR upgrades our Node dependency to v12, which is an LTS release supported until April 2022. It also does minor upgrades to Angular components that have incompatibilities with the new version.